### PR TITLE
Set stopAtEntry to false in globaltool.launch.json.template

### DIFF
--- a/src/Dotnet.Script.Core/Templates/globaltool.launch.json.template
+++ b/src/Dotnet.Script.Core/Templates/globaltool.launch.json.template
@@ -11,7 +11,7 @@
         "program": "${env:USERPROFILE}/.dotnet/tools/dotnet-script.exe",
       },
       "cwd": "${workspaceFolder}",
-      "stopAtEntry": true,
+      "stopAtEntry": false,
     }
   ]
 }

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -241,7 +241,7 @@ namespace Dotnet.Script.Tests
         [Theory]
         [InlineData("https://gist.githubusercontent.com/seesharper/5d6859509ea8364a1fdf66bbf5b7923d/raw/0a32bac2c3ea807f9379a38e251d93e39c8131cb/HelloWorld.csx",
                     "Hello World")]
-        [InlineData("https://github.com/filipw/dotnet-script/files/5035247/hello.csx.gz",
+        [InlineData("https://github.com/dotnet-script/dotnet-script/files/5035247/hello.csx.gz",
                     "Hello, world!")]
         public void ShouldExecuteRemoteScript(string url, string output)
         {


### PR DESCRIPTION
This PR sets the `stopAtEntry` property to `false` in `globaltool.launch.json.template`.
#628 was suppose to fix this, but I forgot that we have two template files. 
This also fixes #673 

Note: Also had to fix one test that had a link to the "old" repo :)
