### PR TITLE
Don't write diagnostics to stdOut

### DIFF
--- a/src/Dotnet.Script.Core/ScriptConsole.cs
+++ b/src/Dotnet.Script.Core/ScriptConsole.cs
@@ -36,22 +36,29 @@ namespace Dotnet.Script.Core
             Console.ResetColor();
         }
 
+        public virtual void WriteWarning(string value)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Error.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
+            Console.ResetColor();
+        }
+
         public virtual void WriteNormal(string value)
         {
             Out.WriteLine(value.TrimEnd(Environment.NewLine.ToCharArray()));
         }
 
-        public virtual void WriteDiagnostics(Diagnostic[] warningDiagnostics, Diagnostic[] errorDiagnostics) 
+        public virtual void WriteDiagnostics(Diagnostic[] warningDiagnostics, Diagnostic[] errorDiagnostics)
         {
-            if (warningDiagnostics != null) 
+            if (warningDiagnostics != null)
             {
                 foreach (var warning in warningDiagnostics)
                 {
-                    WriteHighlighted(warning.ToString());
+                    WriteWarning(warning.ToString());
                 }
             }
 
-            if (errorDiagnostics != null) 
+            if (errorDiagnostics != null)
             {
                 foreach (var error in errorDiagnostics)
                 {

--- a/src/Dotnet.Script.Core/ScriptEmitter.cs
+++ b/src/Dotnet.Script.Core/ScriptEmitter.cs
@@ -23,7 +23,7 @@ namespace Dotnet.Script.Core
             var compilationContext = _scriptCompiler.CreateCompilationContext<TReturn, THost>(context);
             foreach (var warning in compilationContext.Warnings)
             {
-                _scriptConsole.WriteHighlighted(warning.ToString());
+                _scriptConsole.WriteWarning(warning.ToString());
             }
 
             if (compilationContext.Errors.Any())

--- a/src/Dotnet.Script.Shared.Tests/ProcessHelper.cs
+++ b/src/Dotnet.Script.Shared.Tests/ProcessHelper.cs
@@ -6,7 +6,7 @@ namespace Dotnet.Script.Shared.Tests
 {
     public static class ProcessHelper
     {
-        public static (string output, int exitcode) RunAndCaptureOutput(string fileName, string arguments, string workingDirectory = null)
+        public static ProcessResult RunAndCaptureOutput(string fileName, string arguments, string workingDirectory = null)
         {
             var startInfo = new ProcessStartInfo(fileName, arguments)
             {
@@ -29,15 +29,17 @@ namespace Dotnet.Script.Shared.Tests
             catch
             {
                 Console.WriteLine($"Failed to launch '{fileName}' with args, '{arguments}'");
-                return (null, -1);
+                return new ProcessResult(null, -1, null, null);
             }
 
-            var output = process.StandardOutput.ReadToEnd();
-            output += process.StandardError.ReadToEnd();
+            var standardOut = process.StandardOutput.ReadToEnd().Trim();
+            var standardError = process.StandardError.ReadToEnd().Trim();
+
+            var output = standardOut + standardError;
 
             process.WaitForExit();
 
-            return (output.Trim(), process.ExitCode);
+            return new ProcessResult(output, process.ExitCode, standardOut, standardError);
         }
     }
 }

--- a/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
+++ b/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
@@ -4,21 +4,21 @@ namespace Dotnet.Script.Shared.Tests
     {
         public ProcessResult(string output, int exitCode, string standardOut, string standardError)
         {
-            this.output = output;
-            this.exitCode = exitCode;
-            this.standardOut = standardOut;
-            this.standardError = standardError;
+            this.Output = output;
+            this.ExitCode = exitCode;
+            this.StandardOut = standardOut;
+            this.StandardError = standardError;
         }
 
-        public string output { get; }
-        public int exitCode { get; }
-        public string standardOut { get; }
-        public string standardError { get; }
+        public string Output { get; }
+        public int ExitCode { get; }
+        public string StandardOut { get; }
+        public string StandardError { get; }
 
         public void Deconstruct(out string output, out int exitCode)
         {
-            output = this.output;
-            exitCode = this.exitCode;
+            output = this.Output;
+            exitCode = this.ExitCode;
         }
     }
 }

--- a/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
+++ b/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
@@ -2,7 +2,7 @@ namespace Dotnet.Script.Shared.Tests
 {
     public class ProcessResult
     {
-        public ProcessResult(string output, int exitcode, string standardOut, string standardError)
+        public ProcessResult(string output, int exitCode, string standardOut, string standardError)
         {
             this.output = output;
             this.exitCode = exitCode;

--- a/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
+++ b/src/Dotnet.Script.Shared.Tests/ProcessResult.cs
@@ -1,0 +1,24 @@
+namespace Dotnet.Script.Shared.Tests
+{
+    public class ProcessResult
+    {
+        public ProcessResult(string output, int exitcode, string standardOut, string standardError)
+        {
+            this.output = output;
+            this.exitCode = exitCode;
+            this.standardOut = standardOut;
+            this.standardError = standardError;
+        }
+
+        public string output { get; }
+        public int exitCode { get; }
+        public string standardOut { get; }
+        public string standardError { get; }
+
+        public void Deconstruct(out string output, out int exitCode)
+        {
+            output = this.output;
+            exitCode = this.exitCode;
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
+++ b/src/Dotnet.Script.Tests/ExecutionCacheTests.cs
@@ -136,8 +136,8 @@ namespace Dotnet.Script.Tests
         private (string output, string hash) Execute(string pathToScript)
         {
             var result = ScriptTestRunner.Default.Execute(pathToScript);
-            testOutputHelper.WriteLine(result.output);
-            Assert.Equal(0, result.exitCode);
+            testOutputHelper.WriteLine(result.Output);
+            Assert.Equal(0, result.ExitCode);
             string pathToExecutionCache = GetPathToExecutionCache(pathToScript);
             var pathToCacheFile = Path.Combine(pathToExecutionCache, "script.sha256");
             string cachedhash = null;
@@ -146,7 +146,7 @@ namespace Dotnet.Script.Tests
                 cachedhash = File.ReadAllText(pathToCacheFile);
             }
 
-            return (result.output, cachedhash);
+            return (result.Output, cachedhash);
         }
 
         private static string GetPathToExecutionCache(string pathToScript)

--- a/src/Dotnet.Script.Tests/PackageSourceTests.cs
+++ b/src/Dotnet.Script.Tests/PackageSourceTests.cs
@@ -18,8 +18,8 @@ namespace Dotnet.Script.Tests
             var fixture = "ScriptPackage/WithNoNuGetConfig";
             var pathToScriptPackages = ScriptPackagesFixture.GetPathToPackagesFolder();
             var result = ScriptTestRunner.Default.ExecuteFixture(fixture, $"--no-cache -s \"{pathToScriptPackages}\"");
-            Assert.Contains("Hello", result.output);
-            Assert.Equal(0, result.exitCode);
+            Assert.Contains("Hello", result.Output);
+            Assert.Equal(0, result.ExitCode);
         }
 
         [Fact]
@@ -28,8 +28,8 @@ namespace Dotnet.Script.Tests
             var pathToScriptPackages = ScriptPackagesFixture.GetPathToPackagesFolder();
             var code = @"#load \""nuget:ScriptPackageWithMainCsx,1.0.0\"" SayHello();";
             var result = ScriptTestRunner.Default.Execute($"--no-cache -s \"{pathToScriptPackages}\" eval \"{code}\"");
-            Assert.Contains("Hello", result.output);
-            Assert.Equal(0, result.exitCode);
+            Assert.Contains("Hello", result.Output);
+            Assert.Equal(0, result.ExitCode);
         }
     }
 }

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -84,6 +84,14 @@ namespace Dotnet.Script.Tests
         }
 
         [Fact]
+        public void ShouldWriteCompilerWarningsToStandardError()
+        {
+            var result = ScriptTestRunner.Default.ExecuteFixture(fixture: "CompilationWarning", "--no-cache");
+            Assert.True(string.IsNullOrWhiteSpace(result.standardOut));
+            Assert.Contains("CS1998", result.standardError, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void ShouldHandleIssue129()
         {
             var (output, _) = ScriptTestRunner.Default.ExecuteFixture("Issue129");

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -87,8 +87,8 @@ namespace Dotnet.Script.Tests
         public void ShouldWriteCompilerWarningsToStandardError()
         {
             var result = ScriptTestRunner.Default.ExecuteFixture(fixture: "CompilationWarning", "--no-cache");
-            Assert.True(string.IsNullOrWhiteSpace(result.standardOut));
-            Assert.Contains("CS1998", result.standardError, StringComparison.OrdinalIgnoreCase);
+            Assert.True(string.IsNullOrWhiteSpace(result.StandardOut));
+            Assert.Contains("CS1998", result.StandardError, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -254,7 +254,7 @@ namespace Dotnet.Script.Tests
         public void ShouldExecuteRemoteScript(string url, string output)
         {
             var result = ScriptTestRunner.Default.Execute(url);
-            Assert.Contains(output, result.output);
+            Assert.Contains(output, result.Output);
         }
 
         [Fact]
@@ -337,7 +337,7 @@ namespace Dotnet.Script.Tests
 
             // Run once to ensure that it is cached.
             var result = ScriptTestRunner.Default.Execute(pathToScript);
-            Assert.Contains("42", result.output);
+            Assert.Contains("42", result.Output);
 
             // Remove the package from the global NuGet cache
             TestPathUtils.RemovePackageFromGlobalNugetCache("SampleLibrary");
@@ -345,11 +345,11 @@ namespace Dotnet.Script.Tests
             //ScriptTestRunner.Default.ExecuteInProcess(pathToScript);
 
             result = ScriptTestRunner.Default.Execute(pathToScript);
-            Assert.Contains("Try executing/publishing the script", result.output);
+            Assert.Contains("Try executing/publishing the script", result.Output);
 
             // Run again with the '--no-cache' option to assert that the advice actually worked.
             result = ScriptTestRunner.Default.Execute($"{pathToScript} --no-cache");
-            Assert.Contains("42", result.output);
+            Assert.Contains("42", result.Output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPackagesTests.cs
@@ -38,7 +38,7 @@ namespace Dotnet.Script.Tests
 
             // Run once to ensure that it is cached.
             var result = ScriptTestRunner.Default.Execute($"{pathToScriptFile} -s {pathToScriptPackages}");
-            Assert.StartsWith("Hello from netstandard2.0", result.output);
+            Assert.StartsWith("Hello from netstandard2.0", result.Output);
 
             // Remove the package from the global NuGet cache
             TestPathUtils.RemovePackageFromGlobalNugetCache("ScriptPackageWithMainCsx");
@@ -48,7 +48,7 @@ namespace Dotnet.Script.Tests
             File.WriteAllText(pathToScriptFile, code.ToString());
 
             result = ScriptTestRunner.Default.Execute($"{pathToScriptFile} -s {pathToScriptPackages}");
-            Assert.Contains("Try executing/publishing the script", result.output);
+            Assert.Contains("Try executing/publishing the script", result.Output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -126,7 +126,7 @@ namespace Dotnet.Script.Tests
             var dllPath = Path.Combine("publish", "main.dll");
             var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath}", workspaceFolder.Path);
 
-            Assert.Equal(0, dllRunResult.exitCode);
+            Assert.Equal(0, dllRunResult.ExitCode);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Dotnet.Script.Tests
 
             var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath}", workspaceFolder.Path);
 
-            Assert.Equal(0, dllRunResult.exitCode);
+            Assert.Equal(0, dllRunResult.ExitCode);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Dotnet.Script.Tests
             var dllPath = Path.Combine(publishFolder.Path, "main.dll");
             var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath}", publishFolder.Path);
 
-            Assert.Equal(0, dllRunResult.exitCode);
+            Assert.Equal(0, dllRunResult.ExitCode);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Dotnet.Script.Tests
             var dllPath = Path.Combine(workspaceFolder.Path, "publish", assemblyName);
             var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath}", workspaceFolder.Path);
 
-            Assert.Equal(0, dllRunResult.exitCode);
+            Assert.Equal(0, dllRunResult.ExitCode);
         }
 
         [Fact]
@@ -211,8 +211,8 @@ namespace Dotnet.Script.Tests
             var dllPath = Path.Combine(workspaceFolder.Path, "publish", "main.dll");
             var dllRunResult = ScriptTestRunner.Default.Execute($"exec {dllPath} -- w o r l d", workspaceFolder.Path);
 
-            Assert.Equal(0, dllRunResult.exitCode);
-            Assert.Contains("Hello world", dllRunResult.output);
+            Assert.Equal(0, dllRunResult.ExitCode);
+            Assert.Contains("Hello world", dllRunResult.Output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/ScriptRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptRunnerTests.cs
@@ -26,7 +26,7 @@ namespace Dotnet.Script.Tests
         {
             var logFactory = TestOutputHelper.CreateTestLogFactory();
             var scriptCompiler = new ScriptCompiler(logFactory, false);
-
+            
             return new ScriptRunner(scriptCompiler, logFactory, ScriptConsole.Default);
         }
     }

--- a/src/Dotnet.Script.Tests/ScriptTestRunner.cs
+++ b/src/Dotnet.Script.Tests/ScriptTestRunner.cs
@@ -24,7 +24,7 @@ namespace Dotnet.Script.Tests
             _scriptEnvironment = ScriptEnvironment.Default;
         }
 
-        public (string output, int exitCode) Execute(string arguments, string workingDirectory = null)
+        public ProcessResult Execute(string arguments, string workingDirectory = null)
         {
             var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments(arguments), workingDirectory);
             return result;
@@ -35,14 +35,14 @@ namespace Dotnet.Script.Tests
             return Program.Main(arguments?.Split(" ") ?? Array.Empty<string>());
         }
 
-        public (string output, int exitCode) ExecuteFixture(string fixture, string arguments = null, string workingDirectory = null)
+        public ProcessResult ExecuteFixture(string fixture, string arguments = null, string workingDirectory = null)
         {
             var pathToFixture = TestPathUtils.GetPathToTestFixture(fixture);
             var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"\"{pathToFixture}\" {arguments}"), workingDirectory);
             return result;
         }
 
-        public (string output, int exitcode) ExecuteWithScriptPackage(string fixture, string arguments = null, string workingDirectory = null)
+        public ProcessResult ExecuteWithScriptPackage(string fixture, string arguments = null, string workingDirectory = null)
         {
             var pathToScriptPackageFixtures = TestPathUtils.GetPathToTestFixtureFolder("ScriptPackage");
             var pathToFixture = Path.Combine(pathToScriptPackageFixtures, fixture, $"{fixture}.csx");
@@ -67,13 +67,13 @@ namespace Dotnet.Script.Tests
             return Program.Main(allArguments.ToArray());
         }
 
-        public (string output, int exitCode) ExecuteCode(string code)
+        public ProcessResult ExecuteCode(string code)
         {
             var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"eval \"{code}\""));
             return result;
         }
 
-        public (string output, int exitCode) ExecuteCodeInReleaseMode(string code)
+        public ProcessResult ExecuteCodeInReleaseMode(string code)
         {
             var result = ProcessHelper.RunAndCaptureOutput("dotnet", GetDotnetScriptArguments($"-c release eval \"{code}\""));
             return result;

--- a/src/Dotnet.Script.Tests/TestFixtures/CompilationWarning/CompilationWarning.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/CompilationWarning/CompilationWarning.csx
@@ -1,0 +1,3 @@
+public async Task Foo()
+{
+}


### PR DESCRIPTION
This PR fixes #657 by writing warnings from the compiler (Diagnostics) to `stdErr` instead of `stdOut` as we used to. 
As mentioned in the issue this causes "pollution" of the `stdOut` stream and could cause issues when for instance piping the output from `dotnet.script` to another command. 

Tried to make this with as little changes to the tests as possible. We now return a `ProcessResult` with a deconstruct that matches the tuple used in many tests. 

