### PR TITLE
Remove Newtonsoft.Json 

### DIFF
--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -37,6 +37,10 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <!-- End of quick fixes -->
     <PackageReference Include="StrongNamer" Version="0.2.5" PrivateAssets="all" />
+
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Script.DependencyModel.Nuget\Dotnet.Script.DependencyModel.NuGet.csproj" />

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Gapotchenko.FX" Version="2021.1.5" />
     <PackageReference Include="Gapotchenko.FX.Reflection.Loader" Version="2021.2.11" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.0-6.final" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />

--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -2,12 +2,12 @@
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.DependencyModel.Logging;
 using Dotnet.Script.DependencyModel.Process;
-using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 
 namespace Dotnet.Script.Core
@@ -119,7 +119,7 @@ namespace Dotnet.Script.Core
             if (!File.Exists(pathToOmniSharpJson))
             {
                 var omniSharpFileTemplate = TemplateLoader.ReadTemplate("omnisharp.json.template");
-                JObject settings = JObject.Parse(omniSharpFileTemplate);
+                var settings = JsonObject.Parse(omniSharpFileTemplate);
                 settings["script"]["defaultTargetFramework"] = _scriptEnvironment.TargetFramework;
                 File.WriteAllText(pathToOmniSharpJson, settings.ToString());
                 _scriptConsole.WriteSuccess($"...'{pathToOmniSharpJson}' [Created]");

--- a/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
+++ b/src/Dotnet.Script.Core/Versioning/VersionProvider.cs
@@ -2,9 +2,8 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Dotnet.Script.DependencyModel.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Dotnet.Script.Core.Versioning
 {
@@ -16,10 +15,10 @@ namespace Dotnet.Script.Core.Versioning
         private const string UserAgent = "dotnet-script";
         private static readonly string RequestUri = "/repos/dotnet-script/dotnet-script/releases/latest";
 
-         /// <inheritdoc>
+        /// <inheritdoc>
         public async Task<VersionInfo> GetLatestVersion()
         {
-            using(var httpClient = CreateHttpClient())
+            using (var httpClient = CreateHttpClient())
             {
                 var response = await httpClient.GetStringAsync(RequestUri);
                 return ParseTagName(response);
@@ -34,8 +33,8 @@ namespace Dotnet.Script.Core.Versioning
 
             VersionInfo ParseTagName(string json)
             {
-                JObject jsonResult = JObject.Parse(json);
-                return new VersionInfo(jsonResult.SelectToken("tag_name").Value<string>(), isResolved:true);
+                JsonNode jsonResult = JsonNode.Parse(json);
+                return new VersionInfo(jsonResult["tag_name"].GetValue<string>(), isResolved: true);
             }
         }
 
@@ -43,7 +42,7 @@ namespace Dotnet.Script.Core.Versioning
         public VersionInfo GetCurrentVersion()
         {
             var versionAttribute = typeof(VersionProvider).Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().Single();
-            return new VersionInfo(versionAttribute.InformationalVersion, isResolved:true);
+            return new VersionInfo(versionAttribute.InformationalVersion, isResolved: true);
         }
     }
 }

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="6.3.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="5.2.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.3.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>
 

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -469,7 +469,7 @@ namespace Dotnet.Script.Tests
         public void ShouldIsolateScriptAssemblies()
         {
             var (output, _) = ScriptTestRunner.Default.ExecuteFixture("Isolation", "--isolated-load-context");
-            Assert.Contains("10.0.0.0", output);
+            Assert.Contains("2.0.0.0", output);
         }
 
         [Fact]

--- a/src/Dotnet.Script.Tests/TestFixtures/Isolation/Isolation.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/Isolation/Isolation.csx
@@ -1,6 +1,3 @@
-#r "nuget:Newtonsoft.Json, 10.0.1"
-
-using Newtonsoft.Json;
-
-var version = typeof(JsonConvert).Assembly.GetName().Version;
-Console.WriteLine(version);
+#r "nuget: Microsoft.Extensions.Logging.Console, 2.0.0"
+using Microsoft.Extensions.Logging;
+Console.WriteLine(typeof(ConsoleLoggerExtensions).Assembly.GetName().Version);


### PR DESCRIPTION
This PR removes the dependency we have on `Newtonsoft.Json`  and replaces the code with `System.Text.Json`.
`Newtonsoft.Json` has caused quite a few problems over the years since we specify one version in `dotnet-script` while a script might pull in another version.  

`System.Text.Json` is pulled in by default when the host is `net6.0` or `net7.0`. `Dotnet.Script.Core` also support `netstandard2.0` and an conditional package-reference has been added for `System.Text.Json`.

Note: We are not yet completely free from `Newtonsoft.Json` yet since `NuGet.ProjectModel` also has this in its dependency graph, but we have done what we can on the `dotnet-script` side of things and we can close #674 for now.