### PR TITLE
removed unnecessary CS8073 warnings

### DIFF
--- a/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs
+++ b/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs
@@ -22,13 +22,13 @@ namespace Dotnet.Script
             return HandleSkippedTrivia(base.VisitReferenceDirectiveTrivia(node));
         }
 
-        private SyntaxNode HandleSkippedTrivia(SyntaxNode node)
+        private static SyntaxNode HandleSkippedTrivia(SyntaxNode node)
         {
             var skippedTrivia = node.DescendantTrivia().Where(x => x.RawKind == (int)SyntaxKind.SkippedTokensTrivia).FirstOrDefault();
-            if (skippedTrivia != null && skippedTrivia.Token.Kind() != SyntaxKind.None) 
+            if (skippedTrivia.Token.Kind() != SyntaxKind.None) 
             {
                 var firstToken = skippedTrivia.GetStructure().ChildTokens().FirstOrDefault();
-                if (firstToken != null && firstToken.Kind() == SyntaxKind.BadToken && firstToken.ToFullString().Trim() == ";")
+                if (firstToken.Kind() == SyntaxKind.BadToken && firstToken.ToFullString().Trim() == ";")
                 {
                     node = node.ReplaceToken(firstToken, SyntaxFactory.Token(SyntaxKind.None));
                     skippedTrivia = node.DescendantTrivia().Where(x => x.RawKind == (int)SyntaxKind.SkippedTokensTrivia).FirstOrDefault();


### PR DESCRIPTION
SyntaxTrivia and SyntaxToken are non nullable

> /Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(28,17): warning CS8073: The result of the expression is always 'true' since a value of type 'SyntaxTrivia' is never equal to 'null' of type 'SyntaxTrivia?' [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=net6.0]
/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(31,21): warning CS8073: The result of the expression is always 'true' since a value of type 'SyntaxToken' is never equal to 'null' of type 'SyntaxToken?' [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=net6.0]