### PR TITLE
fixed deprecated syntax

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -8,7 +8,7 @@
   },
   "script": {
     "enableScriptNuGetReferences": true,
-    "defaultTargetFramework": "net5.0"
+    "defaultTargetFramework": "net6.0"
   },
   "FormattingOptions": {
       "organizeImports": true,

--- a/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs
+++ b/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs
@@ -25,10 +25,10 @@ namespace Dotnet.Script
         private static SyntaxNode HandleSkippedTrivia(SyntaxNode node)
         {
             var skippedTrivia = node.DescendantTrivia().Where(x => x.RawKind == (int)SyntaxKind.SkippedTokensTrivia).FirstOrDefault();
-            if (skippedTrivia.Token.Kind() != SyntaxKind.None) 
+            if (!skippedTrivia.Token.IsKind(SyntaxKind.None)) 
             {
                 var firstToken = skippedTrivia.GetStructure().ChildTokens().FirstOrDefault();
-                if (firstToken.Kind() == SyntaxKind.BadToken && firstToken.ToFullString().Trim() == ";")
+                if (firstToken.IsKind(SyntaxKind.BadToken) && firstToken.ToFullString().Trim() == ";")
                 {
                     node = node.ReplaceToken(firstToken, SyntaxFactory.Token(SyntaxKind.None));
                     skippedTrivia = node.DescendantTrivia().Where(x => x.RawKind == (int)SyntaxKind.SkippedTokensTrivia).FirstOrDefault();


### PR DESCRIPTION
Fixes the build warnings

> /Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(28,17): warning RS1034: Prefer 'IsKind' for checking syntax kinds [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=netstandard2.0]
/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(31,21): warning RS1034: Prefer 'IsKind' for checking syntax kinds [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=netstandard2.0]
/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(28,17): warning RS1034: Prefer 'IsKind' for checking syntax kinds [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=net6.0]
/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Internal/PreprocessorLineRewriter.cs(31,21): warning RS1034: Prefer 'IsKind' for checking syntax kinds [/Users/filipw/dev/dotnet-script/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj::TargetFramework=net6.0]
    4 Warning(s)
    0 Error(s)