### PR TITLE
allow DOTNET_SCRIPT_CACHE_LOCATION to be relative

### DIFF
--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -54,6 +54,7 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
 
             if (!string.IsNullOrEmpty(cachePath))
             {
+                // if the path is not absolute, make it relative to the current folder
                 if (!Path.IsPathRooted(cachePath)) 
                 {
                     cachePath = Path.Combine(Directory.GetCurrentDirectory(), cachePath);

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/FileUtils.cs
@@ -1,9 +1,9 @@
-﻿using Dotnet.Script.DependencyModel.Environment;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using Dotnet.Script.DependencyModel.Environment;
 using SysEnvironment = System.Environment;
 
 namespace Dotnet.Script.DependencyModel.ProjectSystem
@@ -51,8 +51,13 @@ namespace Dotnet.Script.DependencyModel.ProjectSystem
         {
             // prefer the custom env variable if set
             var cachePath = SysEnvironment.GetEnvironmentVariable("DOTNET_SCRIPT_CACHE_LOCATION");
+
             if (!string.IsNullOrEmpty(cachePath))
             {
+                if (!Path.IsPathRooted(cachePath)) 
+                {
+                    cachePath = Path.Combine(Directory.GetCurrentDirectory(), cachePath);
+                }
                 return cachePath;
             }
 

--- a/src/Dotnet.Script.Tests/FileUtilsTests.cs
+++ b/src/Dotnet.Script.Tests/FileUtilsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using Dotnet.Script.DependencyModel.ProjectSystem;
+using Xunit;
+
+namespace Dotnet.Script.Tests
+{
+    public class FileUtilsTests
+    {
+        [Fact]
+        public void GetTempPathCanBeOverridenWithAbsolutePathViaEnvVar()
+        {
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            try 
+            {
+                Environment.SetEnvironmentVariable("DOTNET_SCRIPT_CACHE_LOCATION", path);
+                var tempPath = FileUtils.GetTempPath();
+                Assert.Equal(path, tempPath);
+            } 
+            finally 
+            {
+                Environment.SetEnvironmentVariable("DOTNET_SCRIPT_CACHE_LOCATION", null);
+            }
+        }
+
+        [Fact]
+        public void GetTempPathCanBeOverridenWithRelativePathViaEnvVar()
+        {
+            var path = "foo";
+            try 
+            {
+                Environment.SetEnvironmentVariable("DOTNET_SCRIPT_CACHE_LOCATION", path);
+                var tempPath = FileUtils.GetTempPath();
+                Assert.Equal(Path.Combine(Directory.GetCurrentDirectory(), path), tempPath);
+            } 
+            finally 
+            {
+                Environment.SetEnvironmentVariable("DOTNET_SCRIPT_CACHE_LOCATION", null);
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.Tests/NuGetSourceReferenceResolverTests.cs
+++ b/src/Dotnet.Script.Tests/NuGetSourceReferenceResolverTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text;


### PR DESCRIPTION
If the path retrieved from DOTNET_SCRIPT_CACHE_LOCATION is not absolute, we will make it relative to the current folder.

Fixes #658 