### PR TITLE
Remove hardwired return type in ExecuteScriptCommand

### DIFF
--- a/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/ExecuteScriptCommand.cs
@@ -31,7 +31,7 @@ namespace Dotnet.Script.Core.Commands
                 return await DownloadAndRunCode<TReturn>(options);
             }
 
-            var pathToLibrary = GetLibrary(options);
+            var pathToLibrary = GetLibrary<TReturn>(options);
 
             var libraryOptions = new ExecuteLibraryCommandOptions(pathToLibrary, options.Arguments, options.NoCache)
             {
@@ -50,7 +50,7 @@ namespace Dotnet.Script.Core.Commands
             return await new ExecuteCodeCommand(_scriptConsole, _logFactory).Execute<TReturn>(options);
         }
 
-        private string GetLibrary(ExecuteScriptCommandOptions executeOptions)
+        private string GetLibrary<TReturn>(ExecuteScriptCommandOptions executeOptions)
         {
             var projectFolder = FileUtils.GetPathToScriptTempFolder(executeOptions.File.Path);
             var executionCacheFolder = Path.Combine(projectFolder, "execution-cache");
@@ -70,7 +70,7 @@ namespace Dotnet.Script.Core.Commands
                 AssemblyLoadContext = executeOptions.AssemblyLoadContext
 #endif
             };
-            new PublishCommand(_scriptConsole, _logFactory).Execute(options);
+            new PublishCommand(_scriptConsole, _logFactory).Execute<TReturn>(options);
             if (hash != null)
             {
                 File.WriteAllText(Path.Combine(executionCacheFolder, "script.sha256"), hash);

--- a/src/Dotnet.Script.Core/Commands/PublishCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommand.cs
@@ -17,6 +17,11 @@ namespace Dotnet.Script.Core.Commands
             _logFactory = logFactory;
         }
 
+        public void Execute(PublishCommandOptions options)
+        { 
+            Execute<int>(options);
+        }
+
         public void Execute<TReturn>(PublishCommandOptions options)
         {
             var absoluteFilePath = options.File.Path;

--- a/src/Dotnet.Script.Core/Commands/PublishCommand.cs
+++ b/src/Dotnet.Script.Core/Commands/PublishCommand.cs
@@ -17,7 +17,7 @@ namespace Dotnet.Script.Core.Commands
             _logFactory = logFactory;
         }
 
-        public void Execute(PublishCommandOptions options)
+        public void Execute<TReturn>(PublishCommandOptions options)
         {
             var absoluteFilePath = options.File.Path;
 
@@ -41,11 +41,11 @@ namespace Dotnet.Script.Core.Commands
 
             if (options.PublishType == PublishType.Library)
             {
-                publisher.CreateAssembly<int, CommandLineScriptGlobals>(context, _logFactory, options.LibraryName);
+                publisher.CreateAssembly<TReturn, CommandLineScriptGlobals>(context, _logFactory, options.LibraryName);
             }
             else
             {
-                publisher.CreateExecutable<int, CommandLineScriptGlobals>(context, _logFactory, options.RuntimeIdentifier, options.LibraryName);
+                publisher.CreateExecutable<TReturn, CommandLineScriptGlobals>(context, _logFactory, options.RuntimeIdentifier, options.LibraryName);
             }
         }
     }

--- a/src/Dotnet.Script/Program.cs
+++ b/src/Dotnet.Script/Program.cs
@@ -188,7 +188,7 @@ namespace Dotnet.Script
                     );
 
                     var logFactory = CreateLogFactory(verbosity.Value(), debugMode.HasValue());
-                    new PublishCommand(ScriptConsole.Default, logFactory).Execute(options);
+                    new PublishCommand(ScriptConsole.Default, logFactory).Execute<int>(options);
                     return 0;
                 });
             });


### PR DESCRIPTION
ExecuteScriptCommand return type should be generic. This PR removes the hardwired return type, pushes it up to Program.cs and passes generic type.