### PR TITLE
fix InstalledAsGlobalTool checking for Windows

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -141,7 +141,8 @@ namespace Dotnet.Script.Core
             _scriptConsole.WriteNormal("Creating VS Code launch configuration file");
             string pathToLaunchFile = Path.Combine(vsCodeDirectory, "launch.json");
             string installLocation = _scriptEnvironment.InstallLocation;
-            bool isInstalledAsGlobalTool = installLocation.Contains(".dotnet/tools", StringComparison.OrdinalIgnoreCase);
+            bool isInstalledAsGlobalTool = installLocation.Contains(".dotnet/tools", StringComparison.OrdinalIgnoreCase) ||
+                installLocation.Contains(".dotnet\\tools", StringComparison.OrdinalIgnoreCase);
             string dotnetScriptPath = Path.Combine(installLocation, "dotnet-script.dll").Replace(@"\", "/");
             string launchFileContent;
             if (!File.Exists(pathToLaunchFile))


### PR DESCRIPTION
Fixes #722

In Windows, `dotnet-script` will never determined as "installed as global tool" during scaffolding, because Windows use `\\' as path separator mainly.

```C#
bool isInstalledAsGlobalTool = installLocation.Contains(".dotnet/tools", StringComparison.OrdinalIgnoreCase);
```


