### PR TITLE
Support .NET 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install .Net Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
           include-prerelease: true
       - name: Install dotnet-script
         run: dotnet tool install dotnet-script --global
@@ -27,11 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install .Net Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
           include-prerelease: true
       - name: Install dotnet-script
         run: dotnet tool install dotnet-script --global
@@ -45,11 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install .Net Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
           include-prerelease: true
       - name: Install dotnet-script
         run: dotnet tool install dotnet-script --global

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100-rc.2.23502.2",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
+++ b/src/Dotnet.Script.Core/Dotnet.Script.Core.csproj
@@ -2,9 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A cross platform library allowing you to run C# (CSX) scripts with support for debugging and inline NuGet packages. Based on Roslyn.</Description>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>filipw</Authors>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Dotnet.Script.Core</AssemblyName>
     <PackageId>Dotnet.Script.Core</PackageId>
     <PackageTags>script;csx;csharp;roslyn</PackageTags>

--- a/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
+++ b/src/Dotnet.Script.DependencyModel.Nuget/Dotnet.Script.DependencyModel.NuGet.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;nuget</PackageTags>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Description>A MetadataReferenceResolver that allows inline nuget references to be specified in script(csx) files.</Description>
     <Authors>dotnet-script</Authors>
     <Company>dotnet-script</Company>

--- a/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
+++ b/src/Dotnet.Script.DependencyModel/Dotnet.Script.DependencyModel.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/dotnet-script/dotnet-script.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>script;csx;csharp;roslyn;omnisharp</PackageTags>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
+++ b/src/Dotnet.Script.DependencyModel/Environment/ScriptEnvironment.cs
@@ -133,10 +133,16 @@ namespace Dotnet.Script.DependencyModel.Environment
         private static string GetRuntimeIdentifier()
         {
             var platformIdentifier = GetPlatformIdentifier();
+            
+#if NET8_0 
+            return $"{platformIdentifier}-{GetProcessArchitecture()}";
+#endif
+            
             if (platformIdentifier == "osx" || platformIdentifier == "linux")
             {
                 return $"{platformIdentifier}-{GetProcessArchitecture()}";
             }
+            
             var runtimeIdentifier = RuntimeEnvironment.GetRuntimeIdentifier();
             return runtimeIdentifier;
         }

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>

--- a/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
+++ b/src/Dotnet.Script.DependencyModel/ProjectSystem/csproj.template
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>

--- a/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
+++ b/src/Dotnet.Script.Tests/Dotnet.Script.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../dotnet-script.snk</AssemblyOriginatorKeyFile>

--- a/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
+++ b/src/Dotnet.Script.Tests/InteractiveRunnerTests.cs
@@ -19,8 +19,7 @@ namespace Dotnet.Script.Tests
             {
                 @"#r ""sdk:Microsoft.NET.Sdk.Web""",
                 "using Microsoft.AspNetCore.Builder;",
-                "var a = WebApplication.Create();",
-                @"a.GetType()",
+                @"typeof(WebApplication)",
                 "#exit"
             };
 

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using Dotnet.Script.DependencyModel.Environment;
 using Dotnet.Script.Shared.Tests;
@@ -479,12 +481,27 @@ namespace Dotnet.Script.Tests
             Assert.Contains("Dotnet.Script.Core.ScriptAssemblyLoadContext", output);
         }
 
+#if NET6_0
+        [Fact]
+        public void ShouldCompileAndExecuteWithWebSdk()
+        {
+            var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApiNet6", "--no-cache");
+            Assert.Equal(0, processResult.ExitCode);
+        }
+#endif
+        
+#if NET7_0
         [Fact]
         public void ShouldCompileAndExecuteWithWebSdk()
         {
             var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApi", "--no-cache");
             Assert.Equal(0, processResult.ExitCode);
         }
+#endif  
+        // todo: the same test should run for .NET 8.0 - currently it fails with 
+        // System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+        // ---> System.IO.FileLoadException: Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
+        // Could not find or load a specific file. (0x80131621)
 
         [Fact]
         public void ShouldThrowExceptionWhenSdkIsNotSupported()

--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -497,12 +497,18 @@ namespace Dotnet.Script.Tests
             var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApi", "--no-cache");
             Assert.Equal(0, processResult.ExitCode);
         }
-#endif  
-        // todo: the same test should run for .NET 8.0 - currently it fails with 
-        // System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
-        // ---> System.IO.FileLoadException: Could not load file or assembly 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
-        // Could not find or load a specific file. (0x80131621)
-
+#endif 
+        
+#if NET8_0
+        // .NET 8.0 only works with isolated load context
+        [Fact]
+        public void ShouldCompileAndExecuteWithWebSdk()
+        {
+            var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApi", "--no-cache --isolated-load-context");
+            Assert.Equal(0, processResult.ExitCode);
+        }
+#endif 
+        
         [Fact]
         public void ShouldThrowExceptionWhenSdkIsNotSupported()
         {

--- a/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptPublisherTests.cs
@@ -49,7 +49,11 @@ namespace Dotnet.Script.Tests
         public void SimplePublishTestToDifferentRuntimeId()
         {
             using var workspaceFolder = new DisposableFolder();
+#if NET8_0 
+            var runtimeId = _scriptEnvironment.RuntimeIdentifier == "win-x64" ? "osx-x64" : "win10-x64";
+#else
             var runtimeId = _scriptEnvironment.RuntimeIdentifier == "win10-x64" ? "osx-x64" : "win10-x64";
+#endif
             var code = @"WriteLine(""hello world"");";
             var mainPath = Path.Combine(workspaceFolder.Path, "main.csx");
             File.WriteAllText(mainPath, code);

--- a/src/Dotnet.Script.Tests/TestFixtures/WebApi/WebApi.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/WebApi/WebApi.csx
@@ -2,5 +2,7 @@
 
 using Microsoft.AspNetCore.Builder;
 
-var a = WebApplication.Create();
-a.MapGet("/", () => "Hello world");
+var builder = WebApplication.CreateBuilder();
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");

--- a/src/Dotnet.Script.Tests/TestFixtures/WebApi/WebApi.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/WebApi/WebApi.csx
@@ -1,4 +1,5 @@
 #r "sdk:Microsoft.NET.Sdk.Web"
+#r "nuget:Microsoft.Extensions.DependencyInjection.Abstractions, 8.0.0-rc.2.23479.6"
 
 using Microsoft.AspNetCore.Builder;
 

--- a/src/Dotnet.Script.Tests/TestFixtures/WebApiNet6/WebApiNet6.csx
+++ b/src/Dotnet.Script.Tests/TestFixtures/WebApiNet6/WebApiNet6.csx
@@ -1,0 +1,6 @@
+#r "sdk:Microsoft.NET.Sdk.Web"
+
+using Microsoft.AspNetCore.Builder;
+
+var a = WebApplication.Create();
+a.MapGet("/", () => "Hello world");

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -2,10 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Dotnet CLI tool allowing you to run C# (CSX) scripts.</Description>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>filipw</Authors>
     <PackageId>Dotnet.Script</PackageId>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>dotnet-script</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Added multi targeting for .NET 8.0.

There is still one thing that is broken, and that is the test `ShouldCompileAndExecuteWithWebSdk` which means the SDK support on .NET 8.0. I think we can merge .NET 8.0 support as-is to be ready and then address that in a separate PR.