### PR TITLE
conditionally reference appropriate version of Microsoft.Extensions.Logging.Console

### DIFF
--- a/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
+++ b/src/Dotnet.Script.Tests/ScriptExecutionTests.cs
@@ -504,7 +504,7 @@ namespace Dotnet.Script.Tests
         [Fact]
         public void ShouldCompileAndExecuteWithWebSdk()
         {
-            var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApi", "--no-cache --isolated-load-context");
+            var processResult = ScriptTestRunner.Default.ExecuteFixture("WebApi", "--no-cache");
             Assert.Equal(0, processResult.ExitCode);
         }
 #endif 

--- a/src/Dotnet.Script/Dotnet.Script.csproj
+++ b/src/Dotnet.Script/Dotnet.Script.csproj
@@ -27,7 +27,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0"
+                      Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'"/>
+    
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0-rc.2.23479.6"
+                      Condition="'$(TargetFramework)' == 'net8.0'"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dotnet.Script.Core\Dotnet.Script.Core.csproj" />


### PR DESCRIPTION
For .NET 8.0 we should bring in the v8 and for .NET 7.0 the v7.

This allows us to remove the isolated load context from the test.