### PR TITLE
dotnet script register doesn't work after vscode registers for file

### DIFF
--- a/src/Dotnet.Script.Core/Scaffolder.cs
+++ b/src/Dotnet.Script.Core/Scaffolder.cs
@@ -81,6 +81,7 @@ namespace Dotnet.Script.Core
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // register dotnet-script as the tool to process .csx files
+                _commandRunner.Execute("reg", @"delete HKCU\Software\classes\.csx /f");
                 _commandRunner.Execute("reg", @"add HKCU\Software\classes\.csx /f /ve /t REG_SZ /d dotnetscript");
                 _commandRunner.Execute("reg", $@"add HKCU\Software\Classes\dotnetscript\Shell\Open\Command /f /ve /t REG_EXPAND_SZ /d ""\""%ProgramFiles%\dotnet\dotnet.exe\"" script \""%1\"" -- %*""");
             }


### PR DESCRIPTION
dotnet script register doesn't work if VSCode has registered for the csx extension

The solution is to create the delete the .csx key to ensure fresh key for .csx registration.